### PR TITLE
Provide CoroutineScope via Gatt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Provides a Kotlin [Coroutines] powered interaction with **A**ndroid's **B**luetooth **L**ow
 **E**nergy (BLE) framework.
 
+See [Recipes] page for usage examples.
+
 ## API
 
 When feasible, the API closely matches the Android Bluetooth Low Energy API, replacing methods that
@@ -31,9 +33,9 @@ traditionally rely on [`BluetoothGattCallback`] calls with [suspension functions
 
 ```kotlin
 sealed class ConnectGattResult {
-    data class ConnectGattSuccess(val gatt: Gatt) : ConnectGattResult()
-    data class ConnectGattCanceled(val cause: CancellationException) : ConnectGattResult()
-    data class ConnectGattFailure(val cause: Throwable) : ConnectGattResult()
+    data class Success(val gatt: Gatt) : ConnectGattResult()
+    data class Canceled(val cause: CancellationException) : ConnectGattResult()
+    data class Failure(val cause: Throwable) : ConnectGattResult()
 }
 ```
 
@@ -134,131 +136,44 @@ function), if the Coroutine is cancelled then the in-flight connection attempt w
 corresponding [`BluetoothGatt`] will be closed:
 
 ```kotlin
-class ExampleActivity : AppCompatActivity(), CoroutineScope {
+fun connect(context: Context, device: BluetoothDevice) {
+	val deferred = async {
+		device.connectGatt(context, autoConnect = false)
+	}
 
-    protected lateinit var job: Job
-    override val coroutineContext: CoroutineContext
-        get() = job + Dispatchers.Main
+    launch {
+    	delay(1000L) // Assume, for this example, that BLE connection takes more than 1 second.
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        job = Job()
+        // Cancels the `async` Coroutine and automatically closes the underlying `BluetoothGatt`.
+	    deferred.cancel()    	
+    }
 
-        val bluetoothDevice: BluetoothDevice = TODO("Retrieve a `BluetoothDevice` from a scan.")
+    val result = deferred.await() // `result` will be `ConnectGattResult.Canceled`.
+}
+```
 
-        findViewById<Button>(R.id.connect_button).setOnClickListener {
-            launch {
-                // If Activity is destroyed during connection attempt, then `result` will contain
-                // `ConnectGattResult.Canceled`.
-                val result = bluetoothDevice.connectGatt(this@ExampleActivity, autoConnect = false)
+Note that in the above example, if the BLE connection takes less than 1 second, then the
+**established** connection will **not** be cancelled (and `Gatt` will not be closed), and `result`
+will be `ConnectGattResult.Success`.
 
-                // ...
-            }
+### `Gatt` Coroutine Scope
+
+**Able**'s `Gatt` provides a [`CoroutineScope`], allowing any Coroutine builders to be scoped to the
+`Gatt` instance. For example, you can continually read a characteristic and the Coroutine will
+automatically cancel when the `Gatt` is closed (_error handling omitted for simplicity_):
+
+```kotlin
+fun continuallyReadCharacteristic(gatt: Gatt, serviceUuid: UUID, characteristicUuid: UUID) {
+	val characteristic = gatt.getService(serviceUuid)!!.getCharacteristic(characteristicUuid)!!
+
+	// This Coroutine will automatically cancel when `gatt.close()` is called.
+	gatt.launch {
+        while (isActive) {
+        	println("value = ${gatt.readCharacteristic(characteristic).value}")
         }
     }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        job.cancel()
-    }
 }
 ```
-
-In the above example, the connection process is tied to the Activity lifecycle. If the Activity is
-destroyed (e.g. due to device rotation or navigating away from the Activity) then the connection
-attempt will be cancelled. If it is desirable that a connection attempt proceed beyond the Activity
-lifecycle then the [`launch`] can be executed in the global scope via `GlobalScope.launch`, in which
-case the [`Job`] that [`launch`] returns can be used to manually cancel the connection process (when
-desired).
-
-Alternatively, if (for example) an app has an Activity specifically designed to handle the
-connection process, then Android Architecture Component's [`ViewModel`] can be scoped (via
-`CoroutineScope` interface) allowing connection attempts to be tied to the `ViewModel`'s lifecycle:
-
-```kotlin
-class ExampleViewModel(application: Application) : AndroidViewModel(application), CoroutineScope {
-
-    private val job = Job()
-    override val coroutineContext: CoroutineContext
-        get() = job + Dispatchers.Main
-
-    fun connect(bluetoothDevice: BluetoothDevice) {
-        launch {
-            // If ViewModel is destroyed during connection attempt, then `result` will contain
-            // `ConnectGattResult.Canceled`.
-            val result = bluetoothDevice.connectGatt(getApplication(), autoConnect = false)
-
-            // ...
-        }
-    }
-
-    override fun onCleared() {
-        job.cancel()
-    }
-}
-```
-
-Similar to the connection process, after a connection has been established, if a Coroutine is
-cancelled then any `Gatt` operation executing within the Coroutine will be cancelled.
-
-However, unlike the `connectGatt` cancellation handling, an established `Gatt` connection will
-**not** automatically disconnect or close when the Coroutine executing a `Gatt` operation is
-canceled. Special care must be taken to ensure that Bluetooth Low Energy connections are properly
-closed when no longer needed, for example:
-
-```kotlin
-val gatt: Gatt = TODO("Acquire Gatt via `BluetoothDevice.connectGatt` extension function.")
-
-launch {
-    try {
-        gatt.discoverServices()
-        // todo: Assign desired characteristic to `characteristic` variable.
-        val value = gatt.readCharacteristic(characteristic).value
-        gatt.disconnect()
-    } finally {
-        gatt.close()
-    }
-}
-```
-
-The `Gatt` interface adheres to [`Closeable`] which can simplify the above example by using [`use`]:
-
-```kotlin
-val gatt: Gatt = TODO("Acquire Gatt via `BluetoothDevice.connectGatt` extension function.")
-
-gatt.use { // Will close `gatt` if any failures or cancellation occurs.
-    gatt.discoverServices()
-    // todo: Assign desired characteristic to `characteristic` variable.
-    val value = gatt.readCharacteristic(characteristic).value
-    gatt.disconnect()
-}
-```
-
-It may be desirable to manage Bluetooth Low Energy connections entirely manually. In which case,
-Coroutine [`GlobalScope`] can be used for both the connection process and operations performed while
-connected. In which case, the returned `Gatt` object (after successful connection) can be stored and
-later used to disconnect **and** close the underlying `BluetoothGatt`.
-
-## Example
-
-The following code snippet makes a connection to a [`BluetoothDevice`], reads a characteristic,
-then disconnects (_error handling omitted for simplicity_):
-
-```kotlin
-val serviceUuid = "F000AA80-0451-4000-B000-000000000000".toUuid()
-val characteristicUuid = "F000AA83-0451-4000-B000-000000000000".toUuid()
-
-fun fetchCharacteristic(context: Context, device: BluetoothDevice) = launch {
-    device.connectGatt(context, autoConnect = false).let { (it as Success).gatt }.use { gatt ->
-        gatt.discoverServices()
-        val characteristic = gatt.getService(serviceUuid)!!.getCharacteristic(characteristicUuid)!!
-        println("value = ${gatt.readCharacteristic(characteristic).value}")
-        gatt.disconnect()
-    }
-}
-```
-
-See the [Recipes] page for more usage examples.
 
 # Setup
 
@@ -297,20 +212,14 @@ limitations under the License.
 ```
 
 
-[`BluetoothGatt`]: https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html
-[`BluetoothGattCallback`]: https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback.html
-[`BluetoothDevice`]: https://developer.android.com/reference/android/bluetooth/BluetoothDevice.html
-[`BluetoothDevice.connectGatt(context: Context, autoConnect: Boolean, callback: BluetoothCallback): BluetoothGatt?`]: https://developer.android.com/reference/android/bluetooth/BluetoothDevice.html#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)
-[`RemoteException`]: https://developer.android.com/reference/android/os/RemoteException
 [Coroutines]: https://kotlinlang.org/docs/reference/coroutines.html
-[`Closeable`]: https://docs.oracle.com/javase/7/docs/api/java/io/Closeable.html
-[`GlobalScope`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-global-scope/
-[suspension functions]: https://kotlinlang.org/docs/reference/coroutines.html#suspending-functions
-[structured concurrency]: https://medium.com/@elizarov/structured-concurrency-722d765aa952
-[bluetooth permissions]: https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions
-[`Job`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-job/index.html
-[`launch`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/launch.html
-[`ViewModel`]: https://developer.android.com/topic/libraries/architecture/viewmodel
-[`use`]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/use.html
-[`BluetoothAdapter.getDefaultAdapter()`]: https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getDefaultAdapter()
 [Recipes]: documentation/RECIPES.md
+[`BluetoothGattCallback`]: https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback.html
+[suspension functions]: https://kotlinlang.org/docs/reference/coroutines.html#suspending-functions
+[`RemoteException`]: https://developer.android.com/reference/android/os/RemoteException
+[`BluetoothGatt`]: https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html
+[`BluetoothDevice.connectGatt(context: Context, autoConnect: Boolean, callback: BluetoothCallback): BluetoothGatt?`]: https://developer.android.com/reference/android/bluetooth/BluetoothDevice.html#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)
+[`BluetoothAdapter.getDefaultAdapter()`]: https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#getDefaultAdapter()
+[bluetooth permissions]: https://developer.android.com/guide/topics/connectivity/bluetooth#Permissions
+[structured concurrency]: https://medium.com/@elizarov/structured-concurrency-722d765aa952
+[`CoroutineScope`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-coroutine-scope/

--- a/core/src/main/java/CoroutinesGatt.kt
+++ b/core/src/main/java/CoroutinesGatt.kt
@@ -26,13 +26,18 @@ import com.juul.able.experimental.messenger.OnConnectionStateChange
 import com.juul.able.experimental.messenger.OnDescriptorWrite
 import com.juul.able.experimental.messenger.OnMtuChanged
 import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.channels.BroadcastChannel
 import java.util.UUID
+import kotlin.coroutines.experimental.CoroutineContext
 
 class CoroutinesGatt(
     private val bluetoothGatt: BluetoothGatt,
     private val messenger: Messenger
 ) : Gatt {
+
+    private val job = Job()
+    override val coroutineContext: CoroutineContext = job
 
     private val connectionStateMonitor by lazy { ConnectionStateMonitor(this) }
 
@@ -61,6 +66,7 @@ class CoroutinesGatt(
 
     override fun close() {
         Able.verbose { "close → Begin" }
+        job.cancel()
         connectionStateMonitor.close()
         messenger.close()
         bluetoothGatt.close()

--- a/core/src/main/java/CoroutinesGatt.kt
+++ b/core/src/main/java/CoroutinesGatt.kt
@@ -37,7 +37,8 @@ class CoroutinesGatt(
 ) : Gatt {
 
     private val job = Job()
-    override val coroutineContext: CoroutineContext = job
+    override val coroutineContext: CoroutineContext
+        get() = job
 
     private val connectionStateMonitor by lazy { ConnectionStateMonitor(this) }
 

--- a/core/src/main/java/Gatt.kt
+++ b/core/src/main/java/Gatt.kt
@@ -18,6 +18,7 @@ import com.juul.able.experimental.messenger.OnCharacteristicWrite
 import com.juul.able.experimental.messenger.OnConnectionStateChange
 import com.juul.able.experimental.messenger.OnDescriptorWrite
 import com.juul.able.experimental.messenger.OnMtuChanged
+import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.channels.BroadcastChannel
 import java.io.Closeable
 import java.util.UUID
@@ -57,7 +58,7 @@ typealias GattState = Int
  */
 typealias WriteType = Int
 
-interface Gatt : Closeable {
+interface Gatt : Closeable, CoroutineScope {
 
     val onConnectionStateChange: BroadcastChannel<OnConnectionStateChange>
     val onCharacteristicChanged: BroadcastChannel<OnCharacteristicChanged>

--- a/documentation/RECIPES.md
+++ b/documentation/RECIPES.md
@@ -34,8 +34,131 @@ fun connect(context: Context, device: BluetoothDevice) = launch {
     gatt.disconnect()
     gatt.close()
 }
-
 ```
+
+## Coroutine Scopes
+
+### Android `Activity`
+
+In the following example, the connection process is tied to the `Activity` lifecycle. If the
+`Activity` is destroyed (e.g. due to device rotation or navigating away from the `Activity`) then
+the connection attempt will be canceled (i.e. `BluetoothDevice.connectGatt` extension function will
+return `ConnectGattResult.Canceled`). If it is desirable that a connection attempt proceed beyond
+the `Activity` lifecycle, then the [`launch`] can be executed using [`GlobalScope`], in which case
+the [`Job`] that [`launch`] returns can be used to manually cancel the connection process (when
+desired).
+
+```kotlin
+class ExampleActivity : AppCompatActivity(), CoroutineScope {
+
+    protected lateinit var job: Job
+    override val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.Main
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        job = Job()
+
+        val bluetoothDevice: BluetoothDevice = TODO("Retrieve a `BluetoothDevice` from a scan.")
+
+        findViewById<Button>(R.id.connect_button).setOnClickListener {
+            launch {
+                // If Activity is destroyed during connection attempt, then `result` will contain
+                // `ConnectGattResult.Canceled`.
+                val result = bluetoothDevice.connectGatt(this@ExampleActivity, autoConnect = false)
+
+                // ...
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
+    }
+}
+```
+
+### Android `ViewModel`
+
+Alternative to the Android `Activity` scope described above, if (for example) an app has an
+`Activity` specifically designed to handle the connection process, then Android Architecture
+Component's [`ViewModel`] can be scoped (via `CoroutineScope` interface) allowing connection
+attempts to be tied to the `ViewModel`'s lifecycle:
+
+```kotlin
+class ExampleViewModel(application: Application) : AndroidViewModel(application), CoroutineScope {
+
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.Main
+
+    fun connect(bluetoothDevice: BluetoothDevice) {
+        launch {
+            // If ViewModel is destroyed during connection attempt, then `result` will contain
+            // `ConnectGattResult.Canceled`.
+            val result = bluetoothDevice.connectGatt(getApplication(), autoConnect = false)
+
+            // ...
+        }
+    }
+
+    override fun onCleared() {
+        job.cancel()
+    }
+}
+```
+
+## `Gatt` Operation Cancellation
+
+Similar to the connection process, after a connection has been established, if a Coroutine is
+cancelled then any `Gatt` operation executing within the Coroutine will be cancelled.
+
+However, unlike the `connectGatt` cancellation handling, an established `Gatt` connection will
+**not** automatically disconnect or close when the Coroutine executing a `Gatt` operation is
+canceled. Special care must be taken to ensure that Bluetooth Low Energy connections are properly
+closed when no longer needed, for example:
+
+```kotlin
+val gatt: Gatt = TODO("Acquire Gatt via `BluetoothDevice.connectGatt` extension function.")
+
+launch {
+    try {
+        gatt.discoverServices()
+        // todo: Assign desired characteristic to `characteristic` variable.
+        val value = gatt.readCharacteristic(characteristic).value
+        gatt.disconnect()
+    } finally {
+        gatt.close()
+    }
+}
+```
+
+The `Gatt` interface adheres to [`Closeable`] which can simplify the above example by using [`use`]:
+
+```kotlin
+val gatt: Gatt = TODO("Acquire Gatt via `BluetoothDevice.connectGatt` extension function.")
+
+launch {
+    gatt.use { // Will close `gatt` if any failures or cancellation occurs.
+        gatt.discoverServices()
+        // todo: Assign desired characteristic to `characteristic` variable.
+        val value = gatt.readCharacteristic(characteristic).value
+        gatt.disconnect()
+    }
+}
+```
+
+It may be desirable to manage Bluetooth Low Energy connections entirely manually. In which case,
+Coroutine [`GlobalScope`] can be used for the connection process. In which case, the returned `Gatt`
+object (after successful connection) can be stored and later used to disconnect **and** close the
+underlying `BluetoothGatt`.
 
 
 [`BluetoothDevice`]: https://developer.android.com/reference/android/bluetooth/BluetoothDevice.html
+[`launch`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/launch.html
+[`GlobalScope`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-global-scope/
+[`Job`]: https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.experimental/-job/index.html
+[`ViewModel`]: https://developer.android.com/topic/libraries/architecture/viewmodel
+[`Closeable`]: https://docs.oracle.com/javase/7/docs/api/java/io/Closeable.html
+[`use`]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/use.html


### PR DESCRIPTION
This allows Coroutines to be launched via a `Gatt` object that get automagically canceled upon the `Gatt` being closed.