### PR TITLE
Update maven group and JitPack URLs for repository move

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ See the [Recipes] page for more usage examples.
 
 ## Gradle
 
-[![JitPack version](https://jitpack.io/v/JuulLabs/able.svg)](https://jitpack.io/#JuulLabs/able)
+[![JitPack version](https://jitpack.io/v/JUUL-OSS/able.svg)](https://jitpack.io/#JUUL-OSS/able)
 
 To use **Able** in your Android project, setup your `build.gradle` as follows:
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group 'com.github.JuulLabs.able'
+group 'com.github.JUUL-OSS.able'
 
 kotlin.experimental.coroutines 'enable'
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -34,7 +34,7 @@ val gatt = device
 
 ## Gradle
 
-[![JitPack version](https://jitpack.io/v/JuulLabs/able.svg)](https://jitpack.io/#JuulLabs/able)
+[![JitPack version](https://jitpack.io/v/JUUL-OSS/able.svg)](https://jitpack.io/#JUUL-OSS/able)
 
 ```groovy
 repositories {
@@ -42,6 +42,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.github.JuulLabs.able:processor:$version"
+    implementation "com.github.JUUL-OSS.able:processor:$version"
 }
 ```

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group 'com.github.JuulLabs.able'
+group 'com.github.JUUL-OSS.able'
 
 kotlin.experimental.coroutines 'enable'
 

--- a/retry/build.gradle
+++ b/retry/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group 'com.github.JuulLabs.able'
+group 'com.github.JUUL-OSS.able'
 
 kotlin.experimental.coroutines 'enable'
 

--- a/throw/build.gradle
+++ b/throw/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group 'com.github.JuulLabs.able'
+group 'com.github.JUUL-OSS.able'
 
 kotlin.experimental.coroutines 'enable'
 

--- a/timber-logger/README.md
+++ b/timber-logger/README.md
@@ -10,7 +10,7 @@ Able.logger = TimberLogger()
 
 ## Gradle
 
-[![JitPack version](https://jitpack.io/v/JuulLabs/able.svg)](https://jitpack.io/#JuulLabs/able)
+[![JitPack version](https://jitpack.io/v/JUUL-OSS/able.svg)](https://jitpack.io/#JUUL-OSS/able)
 
 ```groovy
 repositories {

--- a/timber-logger/build.gradle
+++ b/timber-logger/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group 'com.github.JuulLabs.able'
+group 'com.github.JUUL-OSS.able'
 
 android {
     compileSdkVersion versions.compileSdk


### PR DESCRIPTION
Updates for the `JuulLabs` → `JUUL-OSS` GitHub organization move.