### PR TITLE
README formatting and URL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.github.JuulLabs.able:core:$version"
+    implementation "com.github.JUUL-OSS.able:core:$version"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,15 +137,15 @@ corresponding [`BluetoothGatt`] will be closed:
 
 ```kotlin
 fun connect(context: Context, device: BluetoothDevice) {
-	val deferred = async {
-		device.connectGatt(context, autoConnect = false)
-	}
+    val deferred = async {
+        device.connectGatt(context, autoConnect = false)
+    }
 
     launch {
-    	delay(1000L) // Assume, for this example, that BLE connection takes more than 1 second.
+        delay(1000L) // Assume, for this example, that BLE connection takes more than 1 second.
 
         // Cancels the `async` Coroutine and automatically closes the underlying `BluetoothGatt`.
-	    deferred.cancel()    	
+        deferred.cancel()
     }
 
     val result = deferred.await() // `result` will be `ConnectGattResult.Canceled`.
@@ -164,12 +164,12 @@ automatically cancel when the `Gatt` is closed (_error handling omitted for simp
 
 ```kotlin
 fun continuallyReadCharacteristic(gatt: Gatt, serviceUuid: UUID, characteristicUuid: UUID) {
-	val characteristic = gatt.getService(serviceUuid)!!.getCharacteristic(characteristicUuid)!!
+    val characteristic = gatt.getService(serviceUuid)!!.getCharacteristic(characteristicUuid)!!
 
-	// This Coroutine will automatically cancel when `gatt.close()` is called.
-	gatt.launch {
+    // This Coroutine will automatically cancel when `gatt.close()` is called.
+    gatt.launch {
         while (isActive) {
-        	println("value = ${gatt.readCharacteristic(characteristic).value}")
+            println("value = ${gatt.readCharacteristic(characteristic).value}")
         }
     }
 }

--- a/retry/README.md
+++ b/retry/README.md
@@ -12,7 +12,7 @@ val gatt = device
 
 ## Gradle
 
-[![JitPack version](https://jitpack.io/v/JuulLabs/able.svg)](https://jitpack.io/#JuulLabs/able)
+[![JitPack version](https://jitpack.io/v/JUUL-OSS/able.svg)](https://jitpack.io/#JUUL-OSS/able)
 
 ```groovy
 repositories {
@@ -20,6 +20,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.github.JuulLabs.able:retry:$version"
+    implementation "com.github.JUUL-OSS.able:retry:$version"
 }
 ```

--- a/throw/README.md
+++ b/throw/README.md
@@ -22,7 +22,7 @@ fun connect(context: Context, device: BluetoothDevice) = launch {
 
 ## Gradle
 
-[![JitPack version](https://jitpack.io/v/JuulLabs/able.svg)](https://jitpack.io/#JuulLabs/able)
+[![JitPack version](https://jitpack.io/v/JUUL-OSS/able.svg)](https://jitpack.io/#JUUL-OSS/able)
 
 ```groovy
 repositories {
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.github.JuulLabs.able:throw:$version"
+    implementation "com.github.JUUL-OSS.able:throw:$version"
 }
 ```

--- a/timber-logger/README.md
+++ b/timber-logger/README.md
@@ -18,6 +18,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.github.JuulLabs.able:timber-logger:$version"
+    implementation "com.github.JUUL-OSS.able:timber-logger:$version"
 }
 ```


### PR DESCRIPTION
Accidentally mixed in some tabs for indentation into the README, so replacing them with spaces so the README renders as expected on the GitHub page.

Updated JitPack URLs that were previously missed (for the repository move).